### PR TITLE
Updated pt-BR translation, removed duplicate word in en and de

### DIFF
--- a/content/themes/candidus/locales/de.json
+++ b/content/themes/candidus/locales/de.json
@@ -86,6 +86,5 @@
 	"Bookmark this paragraph": "Bookmark this paragraph",
 	"Tweet this quote": "Tweet this quote",
 	"Show details": "Show details",
-	"Join the discussion": "Join the discussion",
-	"Topics": "Topics"
+	"Join the discussion": "Join the discussion"
 }

--- a/content/themes/candidus/locales/en.json
+++ b/content/themes/candidus/locales/en.json
@@ -87,6 +87,5 @@
 	"Bookmark this paragraph": "Bookmark this paragraph",
 	"Tweet this quote": "Tweet this quote",
 	"Show details": "Show details",
-	"Join the discussion": "Join the discussion",
-	"Topics": "Topics"
+	"Join the discussion": "Join the discussion"
 }

--- a/content/themes/candidus/locales/pt-BR.json
+++ b/content/themes/candidus/locales/pt-BR.json
@@ -87,6 +87,5 @@
 	"Bookmark this paragraph": "Destacar esse parágrafo",
 	"Tweet this quote": "Tuitar essa citação",
 	"Show details": "Exibir Detalhes",
-	"Join the discussion": "Participe da conversa",
-	"Topics": "Tópicos"
+	"Join the discussion": "Participe da conversa"
 }

--- a/content/themes/candidus/locales/pt-BR.json
+++ b/content/themes/candidus/locales/pt-BR.json
@@ -6,7 +6,7 @@
 	"{authorname} didn't publish anything yet": "{authorname} não publicou nada ainda",
 	"{authorname} published 1 article": "{authorname} publicou 1 artigo",
 	"{authorname} published % articles": "{authorname} publicou % artigos",
-	"Writing from": "Escrito por",
+	"Writing from": "Escreve em",
 	"{authorname}'s publications": "Publicações de {authorname}",
 
 	"Tags": "Tags",
@@ -84,7 +84,7 @@
 	"Continue reading": "Continuar a leitura",
 	"by": "por",
 	"Copy selected text to the clipboard": "Copiar texto selecionado",
-	"Bookmark this paragraph": "Destacar esse parágrafago",
+	"Bookmark this paragraph": "Destacar esse parágrafo",
 	"Tweet this quote": "Tuitar essa citação",
 	"Show details": "Exibir Detalhes",
 	"Join the discussion": "Participe da conversa",


### PR DESCRIPTION
Hello, yesterday I added the word "Topics" again and ended up duplicating it in the json files. I have already corrected the error. 
I also received a two-word suggestion in pt-BR and I have already updated it in json.
